### PR TITLE
Refactor/add 8 box option

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "web3": "^1.8.2"
   },
   "scripts": {
-    "start": "start public/game.log && react-app-rewired start",
+    "start": "react-app-rewired start",
     "build": "set \"GENERATE_SOURCEMAP=false\" && react-app-rewired build",
     "test": "react-app-rewired test",
     "eject": "react-app-rewired eject"

--- a/src/config.js
+++ b/src/config.js
@@ -18,6 +18,7 @@ export const EARNING_RATE = {
   2: 1,
   4: 1.5,
   6: 3,
+  8: 5,
   12: 10,
 };
 
@@ -31,9 +32,9 @@ export const USER_STATE_SEED = "USER-STATE-SEED";
 export const VAULT_SEED = "VAULT_SEED";
 export const JACKPOT_SEED = "JACKPOT_SEED";
 
-export const BOX_COUNT = [2, 4, 6, 12];
-export const WIN_PERCENTAGE = [47, 23, 15, 7];
-export const REWARD_MUTIPLIER = [10, 15, 30, 100];
+export const BOX_COUNT = [2, 4, 6, 8, 12];
+export const WIN_PERCENTAGE = [47, 23, 15, 10, 7];
+export const REWARD_MUTIPLIER = [10, 15, 30, 50, 100];
 
 export const BET_RANGE = {
   hedera: { min: 10, max: 500, step: 1 },

--- a/src/pages/HowToPlay.jsx
+++ b/src/pages/HowToPlay.jsx
@@ -10,7 +10,7 @@ const HowToPlay = () => {
           <div className="text-xl my-5">How to play Mystery Box</div>
           <div className="text-xl">
             There are multiple options to choose from; 2 Boxes, 4 Boxes, 6
-            Boxes, or 12 Boxes. The higher box selections, increases the reward
+            Boxes, 8 Boxes or 12 Boxes. The higher box selections, increases the reward
             multiplier, but decreases your chance to win. With 2 Boxes selection
             you maintain a 50/50 win to lose chance. If the user wants to play
             hard for higher reward, then the 12 boxes selection is best for them
@@ -65,6 +65,15 @@ const HowToPlay = () => {
                   <td className="border border-slate-300 p-3">+1500 hbar</td>
                   <td className="border border-slate-300 p-3">+0.15 sol</td>
                   <td className="border border-slate-300 p-3">+6 sol</td>
+                </tr>
+                <tr className="border border-slate-300">
+                  <td className="border border-slate-300 p-3">8 Boxes</td>
+                  <td className="border border-slate-300 p-3">12.25:87.50</td>
+                  <td className="border border-slate-300 p-3">5x Bid</td>
+                  <td className="border border-slate-300 p-3">+50 hbar</td>
+                  <td className="border border-slate-300 p-3">+2500 hbar</td>
+                  <td className="border border-slate-300 p-3">+0.25 sol</td>
+                  <td className="border border-slate-300 p-3">+10 sol</td>
                 </tr>
                 <tr className="border border-slate-300">
                   <td className="border border-slate-300 p-3">12 Boxes</td>

--- a/src/pages/Play.jsx
+++ b/src/pages/Play.jsx
@@ -335,9 +335,17 @@ const Play = () => {
           </button>
           <button
             className={`optionbutton ${
+              numberOfBoxs === 8 ? "selected" : ""
+            } px-3 md:px-6 py-2 md:py-2 text-lg text-bold`}
+            onClick={() => onChangeNumberOfBoxs(8, 3)}
+          >
+            8 Boxes
+          </button>
+          <button
+            className={`optionbutton ${
               numberOfBoxs === 12 ? "selected" : ""
             } px-3 md:px-6 py-2 md:py-2 text-lg text-bold`}
-            onClick={() => onChangeNumberOfBoxs(12, 3)}
+            onClick={() => onChangeNumberOfBoxs(12, 4)}
           >
             12 Boxes
           </button>

--- a/src/pages/Stats.jsx
+++ b/src/pages/Stats.jsx
@@ -57,7 +57,11 @@ const LeaderBoard = () => {
                 <tr className=" " >
                   <td className="text-center  p-1 md:p-3">6 Box - </td>
                   <td className="text-center  p-1 md:p-3">{stats?.totalOf6Boxes || 0}</td>
-                </tr>                     
+                </tr>  
+                <tr className=" " >
+                  <td className="text-center  p-1 md:p-3">8 Box - </td>
+                  <td className="text-center  p-1 md:p-3">{stats?.totalOf8Boxes || 0}</td>
+                </tr>                         
                 <tr className=" " >
                   <td className="text-center  p-1 md:p-3">12 Box - </td>
                   <td className="text-center  p-1 md:p-3">{stats?.totalOf12Boxes || 0}</td>


### PR DESCRIPTION
- Added Button to support 8 Box bet

![image](https://user-images.githubusercontent.com/96959686/234078602-22355794-2f78-4e49-9e17-0173bb45d694.png)

- Added Stats for Total 8 box openers **Require API UPDATE** https://pmxgaming.link/api/PlayHistory/stats need to include `sums.totalOf8Boxes` value

![image](https://user-images.githubusercontent.com/96959686/234078920-9384c622-5249-40ac-8615-cefd8f3607f8.png)

- Updated **How to Play** to include Box options for 8 Boxes (Took assumption of 5x profit on 1/8 probablity bet)

![image](https://user-images.githubusercontent.com/96959686/234079522-a44fe60e-23b6-48b2-ade3-85150f1cd7e7.png)

- Updated **config.js** file to include 8 for EARNING_RATE, BOX_COUNT, WIN_PERCENTAGE, REWARD_MUTIPLIER